### PR TITLE
updated 2012 data with newly processed raw data

### DIFF
--- a/2012/20121106__mi__special__general__precinct.csv
+++ b/2012/20121106__mi__special__general__precinct.csv
@@ -1235,6 +1235,18 @@ Wayne,Van Buren Township 10,U.S. House,11,LIB,John J. Tatar,34
 Wayne,Van Buren Township 10,U.S. House,11,UST,Marc J. Sosnowski,16
 Wayne,Van Buren Township 10,U.S. House,11,DEM,David A. Curson,351
 Wayne,Van Buren Township 10,U.S. House,11,REP,Kerry Bentivolio,194
+Wayne,Van Buren Township 911 AVCB,U.S. House,11,NPA,James Leonard Van Gilder,0
+Wayne,Van Buren Township 911 AVCB,U.S. House,11,NPA,Donald R. Green,0
+Wayne,Van Buren Township 911 AVCB,U.S. House,11,LIB,John J. Tatar,27
+Wayne,Van Buren Township 911 AVCB,U.S. House,11,UST,Marc J. Sosnowski,34
+Wayne,Van Buren Township 911 AVCB,U.S. House,11,DEM,David A. Curson,1334
+Wayne,Van Buren Township 911 AVCB,U.S. House,11,REP,Kerry Bentivolio,541
+Wayne,Van Buren Township 912 AVCB,U.S. House,11,NPA,James Leonard Van Gilder,0
+Wayne,Van Buren Township 912 AVCB,U.S. House,11,NPA,Donald R. Green,0
+Wayne,Van Buren Township 912 AVCB,U.S. House,11,LIB,John J. Tatar,49
+Wayne,Van Buren Township 912 AVCB,U.S. House,11,UST,Marc J. Sosnowski,38
+Wayne,Van Buren Township 912 AVCB,U.S. House,11,DEM,David A. Curson,1381
+Wayne,Van Buren Township 912 AVCB,U.S. House,11,REP,Kerry Bentivolio,892
 Wayne,Belleville City 1,U.S. House,11,NPA,James Leonard Van Gilder,0
 Wayne,Belleville City 1,U.S. House,11,NPA,Donald R. Green,0
 Wayne,Belleville City 1,U.S. House,11,LIB,John J. Tatar,23
@@ -1301,6 +1313,24 @@ Wayne,Dearborn Heights City 16,U.S. House,11,LIB,John J. Tatar,12
 Wayne,Dearborn Heights City 16,U.S. House,11,UST,Marc J. Sosnowski,12
 Wayne,Dearborn Heights City 16,U.S. House,11,DEM,David A. Curson,177
 Wayne,Dearborn Heights City 16,U.S. House,11,REP,Kerry Bentivolio,79
+Wayne,Dearborn Heights City 928 AVCB,U.S. House,11,NPA,James Leonard Van Gilder,0
+Wayne,Dearborn Heights City 928 AVCB,U.S. House,11,NPA,Donald R. Green,0
+Wayne,Dearborn Heights City 928 AVCB,U.S. House,11,LIB,John J. Tatar,0
+Wayne,Dearborn Heights City 928 AVCB,U.S. House,11,UST,Marc J. Sosnowski,7
+Wayne,Dearborn Heights City 928 AVCB,U.S. House,11,DEM,David A. Curson,109
+Wayne,Dearborn Heights City 928 AVCB,U.S. House,11,REP,Kerry Bentivolio,45
+Wayne,Dearborn Heights City 929 AVCB,U.S. House,11,NPA,James Leonard Van Gilder,0
+Wayne,Dearborn Heights City 929 AVCB,U.S. House,11,NPA,Donald R. Green,0
+Wayne,Dearborn Heights City 929 AVCB,U.S. House,11,LIB,John J. Tatar,15
+Wayne,Dearborn Heights City 929 AVCB,U.S. House,11,UST,Marc J. Sosnowski,36
+Wayne,Dearborn Heights City 929 AVCB,U.S. House,11,DEM,David A. Curson,523
+Wayne,Dearborn Heights City 929 AVCB,U.S. House,11,REP,Kerry Bentivolio,355
+Wayne,Dearborn Heights City 930 AVCB,U.S. House,11,NPA,James Leonard Van Gilder,0
+Wayne,Dearborn Heights City 930 AVCB,U.S. House,11,NPA,Donald R. Green,0
+Wayne,Dearborn Heights City 930 AVCB,U.S. House,11,LIB,John J. Tatar,7
+Wayne,Dearborn Heights City 930 AVCB,U.S. House,11,UST,Marc J. Sosnowski,14
+Wayne,Dearborn Heights City 930 AVCB,U.S. House,11,DEM,David A. Curson,201
+Wayne,Dearborn Heights City 930 AVCB,U.S. House,11,REP,Kerry Bentivolio,167
 Wayne,Garden City 1,U.S. House,11,NPA,James Leonard Van Gilder,0
 Wayne,Garden City 1,U.S. House,11,NPA,Donald R. Green,0
 Wayne,Garden City 1,U.S. House,11,LIB,John J. Tatar,52
@@ -1679,6 +1709,18 @@ Wayne,Livonia City 908 AVCB,U.S. House,11,LIB,John J. Tatar,35
 Wayne,Livonia City 908 AVCB,U.S. House,11,UST,Marc J. Sosnowski,14
 Wayne,Livonia City 908 AVCB,U.S. House,11,DEM,David A. Curson,267
 Wayne,Livonia City 908 AVCB,U.S. House,11,REP,Kerry Bentivolio,293
+Wayne,Northville City 1,U.S. House,11,NPA,James Leonard Van Gilder,0
+Wayne,Northville City 1,U.S. House,11,NPA,Donald R. Green,0
+Wayne,Northville City 1,U.S. House,11,LIB,John J. Tatar,38
+Wayne,Northville City 1,U.S. House,11,UST,Marc J. Sosnowski,21
+Wayne,Northville City 1,U.S. House,11,DEM,David A. Curson,365
+Wayne,Northville City 1,U.S. House,11,REP,Kerry Bentivolio,524
+Wayne,Northville City 901 AVCB,U.S. House,11,NPA,James Leonard Van Gilder,0
+Wayne,Northville City 901 AVCB,U.S. House,11,NPA,Donald R. Green,0
+Wayne,Northville City 901 AVCB,U.S. House,11,LIB,John J. Tatar,22
+Wayne,Northville City 901 AVCB,U.S. House,11,UST,Marc J. Sosnowski,6
+Wayne,Northville City 901 AVCB,U.S. House,11,DEM,David A. Curson,314
+Wayne,Northville City 901 AVCB,U.S. House,11,REP,Kerry Bentivolio,337
 Wayne,Plymouth City 1,U.S. House,11,NPA,James Leonard Van Gilder,0
 Wayne,Plymouth City 1,U.S. House,11,NPA,Donald R. Green,0
 Wayne,Plymouth City 1,U.S. House,11,LIB,John J. Tatar,56
@@ -2039,3 +2081,9 @@ Wayne,Westland City 905 AVCB,U.S. House,11,LIB,John J. Tatar,39
 Wayne,Westland City 905 AVCB,U.S. House,11,UST,Marc J. Sosnowski,52
 Wayne,Westland City 905 AVCB,U.S. House,11,DEM,David A. Curson,1266
 Wayne,Westland City 905 AVCB,U.S. House,11,REP,Kerry Bentivolio,760
+Wayne,9999,U.S. House,11,NPA,James Leonard Van Gilder,8
+Wayne,9999,U.S. House,11,NPA,Donald R. Green,0
+Wayne,9999,U.S. House,11,LIB,John J. Tatar,0
+Wayne,9999,U.S. House,11,UST,Marc J. Sosnowski,0
+Wayne,9999,U.S. House,11,DEM,David A. Curson,0
+Wayne,9999,U.S. House,11,REP,Kerry Bentivolio,0


### PR DESCRIPTION
I notice discrepancies when spot checking against balletopedia results. I grabbed the newest data  from `https://miboecfr.nictusa.com/cgi-bin/cfr/precinct_srch.cgi?elect_year_type=2012GEN&county_code=00&Submit=Search` and it resolved those discrepancies. 