### PR TITLE
Remove prefix from precinct names

### DIFF
--- a/2020/counties/20201103__mi__general__allegan__precinct.csv
+++ b/2020/counties/20201103__mi__general__allegan__precinct.csv
@@ -45,18 +45,18 @@ Allegan,"City of Holland, Ward 5, Precinct 11 (Ottawa)",Ballots Cast,,,,969
 Allegan,"City of Holland, Ward 5, Precinct 12 (Ottawa)",Ballots Cast,,,,1090
 Allegan,"City of Holland, Ward 5, Precinct 13 (Ottawa)",Ballots Cast,,,,1007
 Allegan,"City of South Haven, Ward 3, Precinct 2 (Van Buren County)",Ballots Cast,,,,8
-Allegan,"zByron Township, Precinct 5 (Kent)",Ballots Cast,,,,0
-Allegan,"zPine Grove Township, Precinct 1B (Van Buren)",Ballots Cast,,,,222
-Allegan,"zAlamo Township, Precinct 1 (Kalamazoo)",Ballots Cast,,,,0
-Allegan,"zAlamo Township, Precinct 2 (Kalamazoo)",Ballots Cast,,,,0
-Allegan,"zCooper Township, Precinct 1 (Kalamazoo)",Ballots Cast,,,,0
-Allegan,"zCooper Township, Precinct 2 (Kalamazoo)",Ballots Cast,,,,0
-Allegan,"zCooper Township, Precinct 4 (Kalamazoo)",Ballots Cast,,,,0
-Allegan,"zOshtemo Township, Precinct 1 (Kalamazoo)",Ballots Cast,,,,0
-Allegan,"zOrangeville Township, Precinct 1 (Barry)",Ballots Cast,,,,221
-Allegan,"zYankee Springs Township, Precinct 1W (Barry)",Ballots Cast,,,,61
-Allegan,"zYankee Springs Township, Precinct 2W (Barry)",Ballots Cast,,,,439
-Allegan,"zPrairieville Township, Precinct 1PL (Barry)",Ballots Cast,,,,1
+Allegan,"Byron Township, Precinct 5 (Kent)",Ballots Cast,,,,0
+Allegan,"Pine Grove Township, Precinct 1B (Van Buren)",Ballots Cast,,,,222
+Allegan,"Alamo Township, Precinct 1 (Kalamazoo)",Ballots Cast,,,,0
+Allegan,"Alamo Township, Precinct 2 (Kalamazoo)",Ballots Cast,,,,0
+Allegan,"Cooper Township, Precinct 1 (Kalamazoo)",Ballots Cast,,,,0
+Allegan,"Cooper Township, Precinct 2 (Kalamazoo)",Ballots Cast,,,,0
+Allegan,"Cooper Township, Precinct 4 (Kalamazoo)",Ballots Cast,,,,0
+Allegan,"Oshtemo Township, Precinct 1 (Kalamazoo)",Ballots Cast,,,,0
+Allegan,"Orangeville Township, Precinct 1 (Barry)",Ballots Cast,,,,221
+Allegan,"Yankee Springs Township, Precinct 1W (Barry)",Ballots Cast,,,,61
+Allegan,"Yankee Springs Township, Precinct 2W (Barry)",Ballots Cast,,,,439
+Allegan,"Prairieville Township, Precinct 1PL (Barry)",Ballots Cast,,,,1
 Allegan,"City of Allegan, Precinct 1",President,,Joseph R. Biden,DEM,360
 Allegan,"City of Allegan, Precinct 1",President,,Donald J. Trump,REP,359
 Allegan,"City of Allegan, Precinct 1",President,,Jo Jorgensen,LIB,22
@@ -379,90 +379,90 @@ Allegan,"City of South Haven, Ward 3, Precinct 2 (Van Buren County)",President,,
 Allegan,"City of South Haven, Ward 3, Precinct 2 (Van Buren County)",President,,Howie Hawkins,GRN,0
 Allegan,"City of South Haven, Ward 3, Precinct 2 (Van Buren County)",President,,Rocky De La Fuente,NAT,0
 Allegan,"City of South Haven, Ward 3, Precinct 2 (Van Buren County)",President,,Write-Ins,,0
-Allegan,"zByron Township, Precinct 5 (Kent)",President,,Joseph R. Biden,DEM,0
-Allegan,"zByron Township, Precinct 5 (Kent)",President,,Donald J. Trump,REP,0
-Allegan,"zByron Township, Precinct 5 (Kent)",President,,Jo Jorgensen,LIB,0
-Allegan,"zByron Township, Precinct 5 (Kent)",President,,Don Blankenship,UST,0
-Allegan,"zByron Township, Precinct 5 (Kent)",President,,Howie Hawkins,GRN,0
-Allegan,"zByron Township, Precinct 5 (Kent)",President,,Rocky De La Fuente,NAT,0
-Allegan,"zByron Township, Precinct 5 (Kent)",President,,Write-Ins,,0
-Allegan,"zPine Grove Township, Precinct 1B (Van Buren)",President,,Joseph R. Biden,DEM,0
-Allegan,"zPine Grove Township, Precinct 1B (Van Buren)",President,,Donald J. Trump,REP,0
-Allegan,"zPine Grove Township, Precinct 1B (Van Buren)",President,,Jo Jorgensen,LIB,0
-Allegan,"zPine Grove Township, Precinct 1B (Van Buren)",President,,Don Blankenship,UST,0
-Allegan,"zPine Grove Township, Precinct 1B (Van Buren)",President,,Howie Hawkins,GRN,0
-Allegan,"zPine Grove Township, Precinct 1B (Van Buren)",President,,Rocky De La Fuente,NAT,0
-Allegan,"zPine Grove Township, Precinct 1B (Van Buren)",President,,Write-Ins,,0
-Allegan,"zAlamo Township, Precinct 1 (Kalamazoo)",President,,Joseph R. Biden,DEM,0
-Allegan,"zAlamo Township, Precinct 1 (Kalamazoo)",President,,Donald J. Trump,REP,0
-Allegan,"zAlamo Township, Precinct 1 (Kalamazoo)",President,,Jo Jorgensen,LIB,0
-Allegan,"zAlamo Township, Precinct 1 (Kalamazoo)",President,,Don Blankenship,UST,0
-Allegan,"zAlamo Township, Precinct 1 (Kalamazoo)",President,,Howie Hawkins,GRN,0
-Allegan,"zAlamo Township, Precinct 1 (Kalamazoo)",President,,Rocky De La Fuente,NAT,0
-Allegan,"zAlamo Township, Precinct 1 (Kalamazoo)",President,,Write-Ins,,0
-Allegan,"zAlamo Township, Precinct 2 (Kalamazoo)",President,,Joseph R. Biden,DEM,0
-Allegan,"zAlamo Township, Precinct 2 (Kalamazoo)",President,,Donald J. Trump,REP,0
-Allegan,"zAlamo Township, Precinct 2 (Kalamazoo)",President,,Jo Jorgensen,LIB,0
-Allegan,"zAlamo Township, Precinct 2 (Kalamazoo)",President,,Don Blankenship,UST,0
-Allegan,"zAlamo Township, Precinct 2 (Kalamazoo)",President,,Howie Hawkins,GRN,0
-Allegan,"zAlamo Township, Precinct 2 (Kalamazoo)",President,,Rocky De La Fuente,NAT,0
-Allegan,"zAlamo Township, Precinct 2 (Kalamazoo)",President,,Write-Ins,,0
-Allegan,"zCooper Township, Precinct 1 (Kalamazoo)",President,,Joseph R. Biden,DEM,0
-Allegan,"zCooper Township, Precinct 1 (Kalamazoo)",President,,Donald J. Trump,REP,0
-Allegan,"zCooper Township, Precinct 1 (Kalamazoo)",President,,Jo Jorgensen,LIB,0
-Allegan,"zCooper Township, Precinct 1 (Kalamazoo)",President,,Don Blankenship,UST,0
-Allegan,"zCooper Township, Precinct 1 (Kalamazoo)",President,,Howie Hawkins,GRN,0
-Allegan,"zCooper Township, Precinct 1 (Kalamazoo)",President,,Rocky De La Fuente,NAT,0
-Allegan,"zCooper Township, Precinct 1 (Kalamazoo)",President,,Write-Ins,,0
-Allegan,"zCooper Township, Precinct 2 (Kalamazoo)",President,,Joseph R. Biden,DEM,0
-Allegan,"zCooper Township, Precinct 2 (Kalamazoo)",President,,Donald J. Trump,REP,0
-Allegan,"zCooper Township, Precinct 2 (Kalamazoo)",President,,Jo Jorgensen,LIB,0
-Allegan,"zCooper Township, Precinct 2 (Kalamazoo)",President,,Don Blankenship,UST,0
-Allegan,"zCooper Township, Precinct 2 (Kalamazoo)",President,,Howie Hawkins,GRN,0
-Allegan,"zCooper Township, Precinct 2 (Kalamazoo)",President,,Rocky De La Fuente,NAT,0
-Allegan,"zCooper Township, Precinct 2 (Kalamazoo)",President,,Write-Ins,,0
-Allegan,"zCooper Township, Precinct 4 (Kalamazoo)",President,,Joseph R. Biden,DEM,0
-Allegan,"zCooper Township, Precinct 4 (Kalamazoo)",President,,Donald J. Trump,REP,0
-Allegan,"zCooper Township, Precinct 4 (Kalamazoo)",President,,Jo Jorgensen,LIB,0
-Allegan,"zCooper Township, Precinct 4 (Kalamazoo)",President,,Don Blankenship,UST,0
-Allegan,"zCooper Township, Precinct 4 (Kalamazoo)",President,,Howie Hawkins,GRN,0
-Allegan,"zCooper Township, Precinct 4 (Kalamazoo)",President,,Rocky De La Fuente,NAT,0
-Allegan,"zCooper Township, Precinct 4 (Kalamazoo)",President,,Write-Ins,,0
-Allegan,"zOshtemo Township, Precinct 1 (Kalamazoo)",President,,Joseph R. Biden,DEM,0
-Allegan,"zOshtemo Township, Precinct 1 (Kalamazoo)",President,,Donald J. Trump,REP,0
-Allegan,"zOshtemo Township, Precinct 1 (Kalamazoo)",President,,Jo Jorgensen,LIB,0
-Allegan,"zOshtemo Township, Precinct 1 (Kalamazoo)",President,,Don Blankenship,UST,0
-Allegan,"zOshtemo Township, Precinct 1 (Kalamazoo)",President,,Howie Hawkins,GRN,0
-Allegan,"zOshtemo Township, Precinct 1 (Kalamazoo)",President,,Rocky De La Fuente,NAT,0
-Allegan,"zOshtemo Township, Precinct 1 (Kalamazoo)",President,,Write-Ins,,0
-Allegan,"zOrangeville Township, Precinct 1 (Barry)",President,,Joseph R. Biden,DEM,0
-Allegan,"zOrangeville Township, Precinct 1 (Barry)",President,,Donald J. Trump,REP,0
-Allegan,"zOrangeville Township, Precinct 1 (Barry)",President,,Jo Jorgensen,LIB,0
-Allegan,"zOrangeville Township, Precinct 1 (Barry)",President,,Don Blankenship,UST,0
-Allegan,"zOrangeville Township, Precinct 1 (Barry)",President,,Howie Hawkins,GRN,0
-Allegan,"zOrangeville Township, Precinct 1 (Barry)",President,,Rocky De La Fuente,NAT,0
-Allegan,"zOrangeville Township, Precinct 1 (Barry)",President,,Write-Ins,,0
-Allegan,"zYankee Springs Township, Precinct 1W (Barry)",President,,Joseph R. Biden,DEM,0
-Allegan,"zYankee Springs Township, Precinct 1W (Barry)",President,,Donald J. Trump,REP,0
-Allegan,"zYankee Springs Township, Precinct 1W (Barry)",President,,Jo Jorgensen,LIB,0
-Allegan,"zYankee Springs Township, Precinct 1W (Barry)",President,,Don Blankenship,UST,0
-Allegan,"zYankee Springs Township, Precinct 1W (Barry)",President,,Howie Hawkins,GRN,0
-Allegan,"zYankee Springs Township, Precinct 1W (Barry)",President,,Rocky De La Fuente,NAT,0
-Allegan,"zYankee Springs Township, Precinct 1W (Barry)",President,,Write-Ins,,0
-Allegan,"zYankee Springs Township, Precinct 2W (Barry)",President,,Joseph R. Biden,DEM,0
-Allegan,"zYankee Springs Township, Precinct 2W (Barry)",President,,Donald J. Trump,REP,0
-Allegan,"zYankee Springs Township, Precinct 2W (Barry)",President,,Jo Jorgensen,LIB,0
-Allegan,"zYankee Springs Township, Precinct 2W (Barry)",President,,Don Blankenship,UST,0
-Allegan,"zYankee Springs Township, Precinct 2W (Barry)",President,,Howie Hawkins,GRN,0
-Allegan,"zYankee Springs Township, Precinct 2W (Barry)",President,,Rocky De La Fuente,NAT,0
-Allegan,"zYankee Springs Township, Precinct 2W (Barry)",President,,Write-Ins,,0
-Allegan,"zPrairieville Township, Precinct 1PL (Barry)",President,,Joseph R. Biden,DEM,0
-Allegan,"zPrairieville Township, Precinct 1PL (Barry)",President,,Donald J. Trump,REP,0
-Allegan,"zPrairieville Township, Precinct 1PL (Barry)",President,,Jo Jorgensen,LIB,0
-Allegan,"zPrairieville Township, Precinct 1PL (Barry)",President,,Don Blankenship,UST,0
-Allegan,"zPrairieville Township, Precinct 1PL (Barry)",President,,Howie Hawkins,GRN,0
-Allegan,"zPrairieville Township, Precinct 1PL (Barry)",President,,Rocky De La Fuente,NAT,0
-Allegan,"zPrairieville Township, Precinct 1PL (Barry)",President,,Write-Ins,,0
+Allegan,"Byron Township, Precinct 5 (Kent)",President,,Joseph R. Biden,DEM,0
+Allegan,"Byron Township, Precinct 5 (Kent)",President,,Donald J. Trump,REP,0
+Allegan,"Byron Township, Precinct 5 (Kent)",President,,Jo Jorgensen,LIB,0
+Allegan,"Byron Township, Precinct 5 (Kent)",President,,Don Blankenship,UST,0
+Allegan,"Byron Township, Precinct 5 (Kent)",President,,Howie Hawkins,GRN,0
+Allegan,"Byron Township, Precinct 5 (Kent)",President,,Rocky De La Fuente,NAT,0
+Allegan,"Byron Township, Precinct 5 (Kent)",President,,Write-Ins,,0
+Allegan,"Pine Grove Township, Precinct 1B (Van Buren)",President,,Joseph R. Biden,DEM,0
+Allegan,"Pine Grove Township, Precinct 1B (Van Buren)",President,,Donald J. Trump,REP,0
+Allegan,"Pine Grove Township, Precinct 1B (Van Buren)",President,,Jo Jorgensen,LIB,0
+Allegan,"Pine Grove Township, Precinct 1B (Van Buren)",President,,Don Blankenship,UST,0
+Allegan,"Pine Grove Township, Precinct 1B (Van Buren)",President,,Howie Hawkins,GRN,0
+Allegan,"Pine Grove Township, Precinct 1B (Van Buren)",President,,Rocky De La Fuente,NAT,0
+Allegan,"Pine Grove Township, Precinct 1B (Van Buren)",President,,Write-Ins,,0
+Allegan,"Alamo Township, Precinct 1 (Kalamazoo)",President,,Joseph R. Biden,DEM,0
+Allegan,"Alamo Township, Precinct 1 (Kalamazoo)",President,,Donald J. Trump,REP,0
+Allegan,"Alamo Township, Precinct 1 (Kalamazoo)",President,,Jo Jorgensen,LIB,0
+Allegan,"Alamo Township, Precinct 1 (Kalamazoo)",President,,Don Blankenship,UST,0
+Allegan,"Alamo Township, Precinct 1 (Kalamazoo)",President,,Howie Hawkins,GRN,0
+Allegan,"Alamo Township, Precinct 1 (Kalamazoo)",President,,Rocky De La Fuente,NAT,0
+Allegan,"Alamo Township, Precinct 1 (Kalamazoo)",President,,Write-Ins,,0
+Allegan,"Alamo Township, Precinct 2 (Kalamazoo)",President,,Joseph R. Biden,DEM,0
+Allegan,"Alamo Township, Precinct 2 (Kalamazoo)",President,,Donald J. Trump,REP,0
+Allegan,"Alamo Township, Precinct 2 (Kalamazoo)",President,,Jo Jorgensen,LIB,0
+Allegan,"Alamo Township, Precinct 2 (Kalamazoo)",President,,Don Blankenship,UST,0
+Allegan,"Alamo Township, Precinct 2 (Kalamazoo)",President,,Howie Hawkins,GRN,0
+Allegan,"Alamo Township, Precinct 2 (Kalamazoo)",President,,Rocky De La Fuente,NAT,0
+Allegan,"Alamo Township, Precinct 2 (Kalamazoo)",President,,Write-Ins,,0
+Allegan,"Cooper Township, Precinct 1 (Kalamazoo)",President,,Joseph R. Biden,DEM,0
+Allegan,"Cooper Township, Precinct 1 (Kalamazoo)",President,,Donald J. Trump,REP,0
+Allegan,"Cooper Township, Precinct 1 (Kalamazoo)",President,,Jo Jorgensen,LIB,0
+Allegan,"Cooper Township, Precinct 1 (Kalamazoo)",President,,Don Blankenship,UST,0
+Allegan,"Cooper Township, Precinct 1 (Kalamazoo)",President,,Howie Hawkins,GRN,0
+Allegan,"Cooper Township, Precinct 1 (Kalamazoo)",President,,Rocky De La Fuente,NAT,0
+Allegan,"Cooper Township, Precinct 1 (Kalamazoo)",President,,Write-Ins,,0
+Allegan,"Cooper Township, Precinct 2 (Kalamazoo)",President,,Joseph R. Biden,DEM,0
+Allegan,"Cooper Township, Precinct 2 (Kalamazoo)",President,,Donald J. Trump,REP,0
+Allegan,"Cooper Township, Precinct 2 (Kalamazoo)",President,,Jo Jorgensen,LIB,0
+Allegan,"Cooper Township, Precinct 2 (Kalamazoo)",President,,Don Blankenship,UST,0
+Allegan,"Cooper Township, Precinct 2 (Kalamazoo)",President,,Howie Hawkins,GRN,0
+Allegan,"Cooper Township, Precinct 2 (Kalamazoo)",President,,Rocky De La Fuente,NAT,0
+Allegan,"Cooper Township, Precinct 2 (Kalamazoo)",President,,Write-Ins,,0
+Allegan,"Cooper Township, Precinct 4 (Kalamazoo)",President,,Joseph R. Biden,DEM,0
+Allegan,"Cooper Township, Precinct 4 (Kalamazoo)",President,,Donald J. Trump,REP,0
+Allegan,"Cooper Township, Precinct 4 (Kalamazoo)",President,,Jo Jorgensen,LIB,0
+Allegan,"Cooper Township, Precinct 4 (Kalamazoo)",President,,Don Blankenship,UST,0
+Allegan,"Cooper Township, Precinct 4 (Kalamazoo)",President,,Howie Hawkins,GRN,0
+Allegan,"Cooper Township, Precinct 4 (Kalamazoo)",President,,Rocky De La Fuente,NAT,0
+Allegan,"Cooper Township, Precinct 4 (Kalamazoo)",President,,Write-Ins,,0
+Allegan,"Oshtemo Township, Precinct 1 (Kalamazoo)",President,,Joseph R. Biden,DEM,0
+Allegan,"Oshtemo Township, Precinct 1 (Kalamazoo)",President,,Donald J. Trump,REP,0
+Allegan,"Oshtemo Township, Precinct 1 (Kalamazoo)",President,,Jo Jorgensen,LIB,0
+Allegan,"Oshtemo Township, Precinct 1 (Kalamazoo)",President,,Don Blankenship,UST,0
+Allegan,"Oshtemo Township, Precinct 1 (Kalamazoo)",President,,Howie Hawkins,GRN,0
+Allegan,"Oshtemo Township, Precinct 1 (Kalamazoo)",President,,Rocky De La Fuente,NAT,0
+Allegan,"Oshtemo Township, Precinct 1 (Kalamazoo)",President,,Write-Ins,,0
+Allegan,"Orangeville Township, Precinct 1 (Barry)",President,,Joseph R. Biden,DEM,0
+Allegan,"Orangeville Township, Precinct 1 (Barry)",President,,Donald J. Trump,REP,0
+Allegan,"Orangeville Township, Precinct 1 (Barry)",President,,Jo Jorgensen,LIB,0
+Allegan,"Orangeville Township, Precinct 1 (Barry)",President,,Don Blankenship,UST,0
+Allegan,"Orangeville Township, Precinct 1 (Barry)",President,,Howie Hawkins,GRN,0
+Allegan,"Orangeville Township, Precinct 1 (Barry)",President,,Rocky De La Fuente,NAT,0
+Allegan,"Orangeville Township, Precinct 1 (Barry)",President,,Write-Ins,,0
+Allegan,"Yankee Springs Township, Precinct 1W (Barry)",President,,Joseph R. Biden,DEM,0
+Allegan,"Yankee Springs Township, Precinct 1W (Barry)",President,,Donald J. Trump,REP,0
+Allegan,"Yankee Springs Township, Precinct 1W (Barry)",President,,Jo Jorgensen,LIB,0
+Allegan,"Yankee Springs Township, Precinct 1W (Barry)",President,,Don Blankenship,UST,0
+Allegan,"Yankee Springs Township, Precinct 1W (Barry)",President,,Howie Hawkins,GRN,0
+Allegan,"Yankee Springs Township, Precinct 1W (Barry)",President,,Rocky De La Fuente,NAT,0
+Allegan,"Yankee Springs Township, Precinct 1W (Barry)",President,,Write-Ins,,0
+Allegan,"Yankee Springs Township, Precinct 2W (Barry)",President,,Joseph R. Biden,DEM,0
+Allegan,"Yankee Springs Township, Precinct 2W (Barry)",President,,Donald J. Trump,REP,0
+Allegan,"Yankee Springs Township, Precinct 2W (Barry)",President,,Jo Jorgensen,LIB,0
+Allegan,"Yankee Springs Township, Precinct 2W (Barry)",President,,Don Blankenship,UST,0
+Allegan,"Yankee Springs Township, Precinct 2W (Barry)",President,,Howie Hawkins,GRN,0
+Allegan,"Yankee Springs Township, Precinct 2W (Barry)",President,,Rocky De La Fuente,NAT,0
+Allegan,"Yankee Springs Township, Precinct 2W (Barry)",President,,Write-Ins,,0
+Allegan,"Prairieville Township, Precinct 1PL (Barry)",President,,Joseph R. Biden,DEM,0
+Allegan,"Prairieville Township, Precinct 1PL (Barry)",President,,Donald J. Trump,REP,0
+Allegan,"Prairieville Township, Precinct 1PL (Barry)",President,,Jo Jorgensen,LIB,0
+Allegan,"Prairieville Township, Precinct 1PL (Barry)",President,,Don Blankenship,UST,0
+Allegan,"Prairieville Township, Precinct 1PL (Barry)",President,,Howie Hawkins,GRN,0
+Allegan,"Prairieville Township, Precinct 1PL (Barry)",President,,Rocky De La Fuente,NAT,0
+Allegan,"Prairieville Township, Precinct 1PL (Barry)",President,,Write-Ins,,0
 Allegan,"City of Allegan, Precinct 1",Registered Voters,,,,1262
 Allegan,"City of Allegan, Precinct 2",Registered Voters,,,,2611
 Allegan,"City of Douglas, Precinct 1",Registered Voters,,,,1364
@@ -509,18 +509,18 @@ Allegan,"City of Holland, Ward 5, Precinct 11 (Ottawa)",Registered Voters,,,,147
 Allegan,"City of Holland, Ward 5, Precinct 12 (Ottawa)",Registered Voters,,,,1392
 Allegan,"City of Holland, Ward 5, Precinct 13 (Ottawa)",Registered Voters,,,,1850
 Allegan,"City of South Haven, Ward 3, Precinct 2 (Van Buren County)",Registered Voters,,,,8
-Allegan,"zByron Township, Precinct 5 (Kent)",Registered Voters,,,,0
-Allegan,"zPine Grove Township, Precinct 1B (Van Buren)",Registered Voters,,,,0
-Allegan,"zAlamo Township, Precinct 1 (Kalamazoo)",Registered Voters,,,,0
-Allegan,"zAlamo Township, Precinct 2 (Kalamazoo)",Registered Voters,,,,0
-Allegan,"zCooper Township, Precinct 1 (Kalamazoo)",Registered Voters,,,,0
-Allegan,"zCooper Township, Precinct 2 (Kalamazoo)",Registered Voters,,,,0
-Allegan,"zCooper Township, Precinct 4 (Kalamazoo)",Registered Voters,,,,0
-Allegan,"zOshtemo Township, Precinct 1 (Kalamazoo)",Registered Voters,,,,0
-Allegan,"zOrangeville Township, Precinct 1 (Barry)",Registered Voters,,,,0
-Allegan,"zYankee Springs Township, Precinct 1W (Barry)",Registered Voters,,,,0
-Allegan,"zYankee Springs Township, Precinct 2W (Barry)",Registered Voters,,,,0
-Allegan,"zPrairieville Township, Precinct 1PL (Barry)",Registered Voters,,,,0
+Allegan,"Byron Township, Precinct 5 (Kent)",Registered Voters,,,,0
+Allegan,"Pine Grove Township, Precinct 1B (Van Buren)",Registered Voters,,,,0
+Allegan,"Alamo Township, Precinct 1 (Kalamazoo)",Registered Voters,,,,0
+Allegan,"Alamo Township, Precinct 2 (Kalamazoo)",Registered Voters,,,,0
+Allegan,"Cooper Township, Precinct 1 (Kalamazoo)",Registered Voters,,,,0
+Allegan,"Cooper Township, Precinct 2 (Kalamazoo)",Registered Voters,,,,0
+Allegan,"Cooper Township, Precinct 4 (Kalamazoo)",Registered Voters,,,,0
+Allegan,"Oshtemo Township, Precinct 1 (Kalamazoo)",Registered Voters,,,,0
+Allegan,"Orangeville Township, Precinct 1 (Barry)",Registered Voters,,,,0
+Allegan,"Yankee Springs Township, Precinct 1W (Barry)",Registered Voters,,,,0
+Allegan,"Yankee Springs Township, Precinct 2W (Barry)",Registered Voters,,,,0
+Allegan,"Prairieville Township, Precinct 1PL (Barry)",Registered Voters,,,,0
 Allegan,"City of Wayland, Precinct 1",State House,72,Lily Cheng Schulting,DEM,766
 Allegan,"City of Wayland, Precinct 1",State House,72,Steven Johnson,REP,1329
 Allegan,"City of Wayland, Precinct 1",State House,72,Write-Ins,,8
@@ -988,90 +988,90 @@ Allegan,"City of South Haven, Ward 3, Precinct 2 (Van Buren County)",Straight Pa
 Allegan,"City of South Haven, Ward 3, Precinct 2 (Van Buren County)",Straight Party,,Working Class Party,WC,0
 Allegan,"City of South Haven, Ward 3, Precinct 2 (Van Buren County)",Straight Party,,Green Party,GRN,0
 Allegan,"City of South Haven, Ward 3, Precinct 2 (Van Buren County)",Straight Party,,Natural Law Party,NAT,0
-Allegan,"zByron Township, Precinct 5 (Kent)",Straight Party,,Democratic Party,DEM,0
-Allegan,"zByron Township, Precinct 5 (Kent)",Straight Party,,Republican Party,REP,0
-Allegan,"zByron Township, Precinct 5 (Kent)",Straight Party,,Libertarian Party,LIB,0
-Allegan,"zByron Township, Precinct 5 (Kent)",Straight Party,,U.S. Taxpayers Party,UST,0
-Allegan,"zByron Township, Precinct 5 (Kent)",Straight Party,,Working Class Party,WC,0
-Allegan,"zByron Township, Precinct 5 (Kent)",Straight Party,,Green Party,GRN,0
-Allegan,"zByron Township, Precinct 5 (Kent)",Straight Party,,Natural Law Party,NAT,0
-Allegan,"zPine Grove Township, Precinct 1B (Van Buren)",Straight Party,,Democratic Party,DEM,0
-Allegan,"zPine Grove Township, Precinct 1B (Van Buren)",Straight Party,,Republican Party,REP,0
-Allegan,"zPine Grove Township, Precinct 1B (Van Buren)",Straight Party,,Libertarian Party,LIB,0
-Allegan,"zPine Grove Township, Precinct 1B (Van Buren)",Straight Party,,U.S. Taxpayers Party,UST,0
-Allegan,"zPine Grove Township, Precinct 1B (Van Buren)",Straight Party,,Working Class Party,WC,0
-Allegan,"zPine Grove Township, Precinct 1B (Van Buren)",Straight Party,,Green Party,GRN,0
-Allegan,"zPine Grove Township, Precinct 1B (Van Buren)",Straight Party,,Natural Law Party,NAT,0
-Allegan,"zAlamo Township, Precinct 1 (Kalamazoo)",Straight Party,,Democratic Party,DEM,0
-Allegan,"zAlamo Township, Precinct 1 (Kalamazoo)",Straight Party,,Republican Party,REP,0
-Allegan,"zAlamo Township, Precinct 1 (Kalamazoo)",Straight Party,,Libertarian Party,LIB,0
-Allegan,"zAlamo Township, Precinct 1 (Kalamazoo)",Straight Party,,U.S. Taxpayers Party,UST,0
-Allegan,"zAlamo Township, Precinct 1 (Kalamazoo)",Straight Party,,Working Class Party,WC,0
-Allegan,"zAlamo Township, Precinct 1 (Kalamazoo)",Straight Party,,Green Party,GRN,0
-Allegan,"zAlamo Township, Precinct 1 (Kalamazoo)",Straight Party,,Natural Law Party,NAT,0
-Allegan,"zAlamo Township, Precinct 2 (Kalamazoo)",Straight Party,,Democratic Party,DEM,0
-Allegan,"zAlamo Township, Precinct 2 (Kalamazoo)",Straight Party,,Republican Party,REP,0
-Allegan,"zAlamo Township, Precinct 2 (Kalamazoo)",Straight Party,,Libertarian Party,LIB,0
-Allegan,"zAlamo Township, Precinct 2 (Kalamazoo)",Straight Party,,U.S. Taxpayers Party,UST,0
-Allegan,"zAlamo Township, Precinct 2 (Kalamazoo)",Straight Party,,Working Class Party,WC,0
-Allegan,"zAlamo Township, Precinct 2 (Kalamazoo)",Straight Party,,Green Party,GRN,0
-Allegan,"zAlamo Township, Precinct 2 (Kalamazoo)",Straight Party,,Natural Law Party,NAT,0
-Allegan,"zCooper Township, Precinct 1 (Kalamazoo)",Straight Party,,Democratic Party,DEM,0
-Allegan,"zCooper Township, Precinct 1 (Kalamazoo)",Straight Party,,Republican Party,REP,0
-Allegan,"zCooper Township, Precinct 1 (Kalamazoo)",Straight Party,,Libertarian Party,LIB,0
-Allegan,"zCooper Township, Precinct 1 (Kalamazoo)",Straight Party,,U.S. Taxpayers Party,UST,0
-Allegan,"zCooper Township, Precinct 1 (Kalamazoo)",Straight Party,,Working Class Party,WC,0
-Allegan,"zCooper Township, Precinct 1 (Kalamazoo)",Straight Party,,Green Party,GRN,0
-Allegan,"zCooper Township, Precinct 1 (Kalamazoo)",Straight Party,,Natural Law Party,NAT,0
-Allegan,"zCooper Township, Precinct 2 (Kalamazoo)",Straight Party,,Democratic Party,DEM,0
-Allegan,"zCooper Township, Precinct 2 (Kalamazoo)",Straight Party,,Republican Party,REP,0
-Allegan,"zCooper Township, Precinct 2 (Kalamazoo)",Straight Party,,Libertarian Party,LIB,0
-Allegan,"zCooper Township, Precinct 2 (Kalamazoo)",Straight Party,,U.S. Taxpayers Party,UST,0
-Allegan,"zCooper Township, Precinct 2 (Kalamazoo)",Straight Party,,Working Class Party,WC,0
-Allegan,"zCooper Township, Precinct 2 (Kalamazoo)",Straight Party,,Green Party,GRN,0
-Allegan,"zCooper Township, Precinct 2 (Kalamazoo)",Straight Party,,Natural Law Party,NAT,0
-Allegan,"zCooper Township, Precinct 4 (Kalamazoo)",Straight Party,,Democratic Party,DEM,0
-Allegan,"zCooper Township, Precinct 4 (Kalamazoo)",Straight Party,,Republican Party,REP,0
-Allegan,"zCooper Township, Precinct 4 (Kalamazoo)",Straight Party,,Libertarian Party,LIB,0
-Allegan,"zCooper Township, Precinct 4 (Kalamazoo)",Straight Party,,U.S. Taxpayers Party,UST,0
-Allegan,"zCooper Township, Precinct 4 (Kalamazoo)",Straight Party,,Working Class Party,WC,0
-Allegan,"zCooper Township, Precinct 4 (Kalamazoo)",Straight Party,,Green Party,GRN,0
-Allegan,"zCooper Township, Precinct 4 (Kalamazoo)",Straight Party,,Natural Law Party,NAT,0
-Allegan,"zOshtemo Township, Precinct 1 (Kalamazoo)",Straight Party,,Democratic Party,DEM,0
-Allegan,"zOshtemo Township, Precinct 1 (Kalamazoo)",Straight Party,,Republican Party,REP,0
-Allegan,"zOshtemo Township, Precinct 1 (Kalamazoo)",Straight Party,,Libertarian Party,LIB,0
-Allegan,"zOshtemo Township, Precinct 1 (Kalamazoo)",Straight Party,,U.S. Taxpayers Party,UST,0
-Allegan,"zOshtemo Township, Precinct 1 (Kalamazoo)",Straight Party,,Working Class Party,WC,0
-Allegan,"zOshtemo Township, Precinct 1 (Kalamazoo)",Straight Party,,Green Party,GRN,0
-Allegan,"zOshtemo Township, Precinct 1 (Kalamazoo)",Straight Party,,Natural Law Party,NAT,0
-Allegan,"zOrangeville Township, Precinct 1 (Barry)",Straight Party,,Democratic Party,DEM,0
-Allegan,"zOrangeville Township, Precinct 1 (Barry)",Straight Party,,Republican Party,REP,0
-Allegan,"zOrangeville Township, Precinct 1 (Barry)",Straight Party,,Libertarian Party,LIB,0
-Allegan,"zOrangeville Township, Precinct 1 (Barry)",Straight Party,,U.S. Taxpayers Party,UST,0
-Allegan,"zOrangeville Township, Precinct 1 (Barry)",Straight Party,,Working Class Party,WC,0
-Allegan,"zOrangeville Township, Precinct 1 (Barry)",Straight Party,,Green Party,GRN,0
-Allegan,"zOrangeville Township, Precinct 1 (Barry)",Straight Party,,Natural Law Party,NAT,0
-Allegan,"zYankee Springs Township, Precinct 1W (Barry)",Straight Party,,Democratic Party,DEM,0
-Allegan,"zYankee Springs Township, Precinct 1W (Barry)",Straight Party,,Republican Party,REP,0
-Allegan,"zYankee Springs Township, Precinct 1W (Barry)",Straight Party,,Libertarian Party,LIB,0
-Allegan,"zYankee Springs Township, Precinct 1W (Barry)",Straight Party,,U.S. Taxpayers Party,UST,0
-Allegan,"zYankee Springs Township, Precinct 1W (Barry)",Straight Party,,Working Class Party,WC,0
-Allegan,"zYankee Springs Township, Precinct 1W (Barry)",Straight Party,,Green Party,GRN,0
-Allegan,"zYankee Springs Township, Precinct 1W (Barry)",Straight Party,,Natural Law Party,NAT,0
-Allegan,"zYankee Springs Township, Precinct 2W (Barry)",Straight Party,,Democratic Party,DEM,0
-Allegan,"zYankee Springs Township, Precinct 2W (Barry)",Straight Party,,Republican Party,REP,0
-Allegan,"zYankee Springs Township, Precinct 2W (Barry)",Straight Party,,Libertarian Party,LIB,0
-Allegan,"zYankee Springs Township, Precinct 2W (Barry)",Straight Party,,U.S. Taxpayers Party,UST,0
-Allegan,"zYankee Springs Township, Precinct 2W (Barry)",Straight Party,,Working Class Party,WC,0
-Allegan,"zYankee Springs Township, Precinct 2W (Barry)",Straight Party,,Green Party,GRN,0
-Allegan,"zYankee Springs Township, Precinct 2W (Barry)",Straight Party,,Natural Law Party,NAT,0
-Allegan,"zPrairieville Township, Precinct 1PL (Barry)",Straight Party,,Democratic Party,DEM,0
-Allegan,"zPrairieville Township, Precinct 1PL (Barry)",Straight Party,,Republican Party,REP,0
-Allegan,"zPrairieville Township, Precinct 1PL (Barry)",Straight Party,,Libertarian Party,LIB,0
-Allegan,"zPrairieville Township, Precinct 1PL (Barry)",Straight Party,,U.S. Taxpayers Party,UST,0
-Allegan,"zPrairieville Township, Precinct 1PL (Barry)",Straight Party,,Working Class Party,WC,0
-Allegan,"zPrairieville Township, Precinct 1PL (Barry)",Straight Party,,Green Party,GRN,0
-Allegan,"zPrairieville Township, Precinct 1PL (Barry)",Straight Party,,Natural Law Party,NAT,0
+Allegan,"Byron Township, Precinct 5 (Kent)",Straight Party,,Democratic Party,DEM,0
+Allegan,"Byron Township, Precinct 5 (Kent)",Straight Party,,Republican Party,REP,0
+Allegan,"Byron Township, Precinct 5 (Kent)",Straight Party,,Libertarian Party,LIB,0
+Allegan,"Byron Township, Precinct 5 (Kent)",Straight Party,,U.S. Taxpayers Party,UST,0
+Allegan,"Byron Township, Precinct 5 (Kent)",Straight Party,,Working Class Party,WC,0
+Allegan,"Byron Township, Precinct 5 (Kent)",Straight Party,,Green Party,GRN,0
+Allegan,"Byron Township, Precinct 5 (Kent)",Straight Party,,Natural Law Party,NAT,0
+Allegan,"Pine Grove Township, Precinct 1B (Van Buren)",Straight Party,,Democratic Party,DEM,0
+Allegan,"Pine Grove Township, Precinct 1B (Van Buren)",Straight Party,,Republican Party,REP,0
+Allegan,"Pine Grove Township, Precinct 1B (Van Buren)",Straight Party,,Libertarian Party,LIB,0
+Allegan,"Pine Grove Township, Precinct 1B (Van Buren)",Straight Party,,U.S. Taxpayers Party,UST,0
+Allegan,"Pine Grove Township, Precinct 1B (Van Buren)",Straight Party,,Working Class Party,WC,0
+Allegan,"Pine Grove Township, Precinct 1B (Van Buren)",Straight Party,,Green Party,GRN,0
+Allegan,"Pine Grove Township, Precinct 1B (Van Buren)",Straight Party,,Natural Law Party,NAT,0
+Allegan,"Alamo Township, Precinct 1 (Kalamazoo)",Straight Party,,Democratic Party,DEM,0
+Allegan,"Alamo Township, Precinct 1 (Kalamazoo)",Straight Party,,Republican Party,REP,0
+Allegan,"Alamo Township, Precinct 1 (Kalamazoo)",Straight Party,,Libertarian Party,LIB,0
+Allegan,"Alamo Township, Precinct 1 (Kalamazoo)",Straight Party,,U.S. Taxpayers Party,UST,0
+Allegan,"Alamo Township, Precinct 1 (Kalamazoo)",Straight Party,,Working Class Party,WC,0
+Allegan,"Alamo Township, Precinct 1 (Kalamazoo)",Straight Party,,Green Party,GRN,0
+Allegan,"Alamo Township, Precinct 1 (Kalamazoo)",Straight Party,,Natural Law Party,NAT,0
+Allegan,"Alamo Township, Precinct 2 (Kalamazoo)",Straight Party,,Democratic Party,DEM,0
+Allegan,"Alamo Township, Precinct 2 (Kalamazoo)",Straight Party,,Republican Party,REP,0
+Allegan,"Alamo Township, Precinct 2 (Kalamazoo)",Straight Party,,Libertarian Party,LIB,0
+Allegan,"Alamo Township, Precinct 2 (Kalamazoo)",Straight Party,,U.S. Taxpayers Party,UST,0
+Allegan,"Alamo Township, Precinct 2 (Kalamazoo)",Straight Party,,Working Class Party,WC,0
+Allegan,"Alamo Township, Precinct 2 (Kalamazoo)",Straight Party,,Green Party,GRN,0
+Allegan,"Alamo Township, Precinct 2 (Kalamazoo)",Straight Party,,Natural Law Party,NAT,0
+Allegan,"Cooper Township, Precinct 1 (Kalamazoo)",Straight Party,,Democratic Party,DEM,0
+Allegan,"Cooper Township, Precinct 1 (Kalamazoo)",Straight Party,,Republican Party,REP,0
+Allegan,"Cooper Township, Precinct 1 (Kalamazoo)",Straight Party,,Libertarian Party,LIB,0
+Allegan,"Cooper Township, Precinct 1 (Kalamazoo)",Straight Party,,U.S. Taxpayers Party,UST,0
+Allegan,"Cooper Township, Precinct 1 (Kalamazoo)",Straight Party,,Working Class Party,WC,0
+Allegan,"Cooper Township, Precinct 1 (Kalamazoo)",Straight Party,,Green Party,GRN,0
+Allegan,"Cooper Township, Precinct 1 (Kalamazoo)",Straight Party,,Natural Law Party,NAT,0
+Allegan,"Cooper Township, Precinct 2 (Kalamazoo)",Straight Party,,Democratic Party,DEM,0
+Allegan,"Cooper Township, Precinct 2 (Kalamazoo)",Straight Party,,Republican Party,REP,0
+Allegan,"Cooper Township, Precinct 2 (Kalamazoo)",Straight Party,,Libertarian Party,LIB,0
+Allegan,"Cooper Township, Precinct 2 (Kalamazoo)",Straight Party,,U.S. Taxpayers Party,UST,0
+Allegan,"Cooper Township, Precinct 2 (Kalamazoo)",Straight Party,,Working Class Party,WC,0
+Allegan,"Cooper Township, Precinct 2 (Kalamazoo)",Straight Party,,Green Party,GRN,0
+Allegan,"Cooper Township, Precinct 2 (Kalamazoo)",Straight Party,,Natural Law Party,NAT,0
+Allegan,"Cooper Township, Precinct 4 (Kalamazoo)",Straight Party,,Democratic Party,DEM,0
+Allegan,"Cooper Township, Precinct 4 (Kalamazoo)",Straight Party,,Republican Party,REP,0
+Allegan,"Cooper Township, Precinct 4 (Kalamazoo)",Straight Party,,Libertarian Party,LIB,0
+Allegan,"Cooper Township, Precinct 4 (Kalamazoo)",Straight Party,,U.S. Taxpayers Party,UST,0
+Allegan,"Cooper Township, Precinct 4 (Kalamazoo)",Straight Party,,Working Class Party,WC,0
+Allegan,"Cooper Township, Precinct 4 (Kalamazoo)",Straight Party,,Green Party,GRN,0
+Allegan,"Cooper Township, Precinct 4 (Kalamazoo)",Straight Party,,Natural Law Party,NAT,0
+Allegan,"Oshtemo Township, Precinct 1 (Kalamazoo)",Straight Party,,Democratic Party,DEM,0
+Allegan,"Oshtemo Township, Precinct 1 (Kalamazoo)",Straight Party,,Republican Party,REP,0
+Allegan,"Oshtemo Township, Precinct 1 (Kalamazoo)",Straight Party,,Libertarian Party,LIB,0
+Allegan,"Oshtemo Township, Precinct 1 (Kalamazoo)",Straight Party,,U.S. Taxpayers Party,UST,0
+Allegan,"Oshtemo Township, Precinct 1 (Kalamazoo)",Straight Party,,Working Class Party,WC,0
+Allegan,"Oshtemo Township, Precinct 1 (Kalamazoo)",Straight Party,,Green Party,GRN,0
+Allegan,"Oshtemo Township, Precinct 1 (Kalamazoo)",Straight Party,,Natural Law Party,NAT,0
+Allegan,"Orangeville Township, Precinct 1 (Barry)",Straight Party,,Democratic Party,DEM,0
+Allegan,"Orangeville Township, Precinct 1 (Barry)",Straight Party,,Republican Party,REP,0
+Allegan,"Orangeville Township, Precinct 1 (Barry)",Straight Party,,Libertarian Party,LIB,0
+Allegan,"Orangeville Township, Precinct 1 (Barry)",Straight Party,,U.S. Taxpayers Party,UST,0
+Allegan,"Orangeville Township, Precinct 1 (Barry)",Straight Party,,Working Class Party,WC,0
+Allegan,"Orangeville Township, Precinct 1 (Barry)",Straight Party,,Green Party,GRN,0
+Allegan,"Orangeville Township, Precinct 1 (Barry)",Straight Party,,Natural Law Party,NAT,0
+Allegan,"Yankee Springs Township, Precinct 1W (Barry)",Straight Party,,Democratic Party,DEM,0
+Allegan,"Yankee Springs Township, Precinct 1W (Barry)",Straight Party,,Republican Party,REP,0
+Allegan,"Yankee Springs Township, Precinct 1W (Barry)",Straight Party,,Libertarian Party,LIB,0
+Allegan,"Yankee Springs Township, Precinct 1W (Barry)",Straight Party,,U.S. Taxpayers Party,UST,0
+Allegan,"Yankee Springs Township, Precinct 1W (Barry)",Straight Party,,Working Class Party,WC,0
+Allegan,"Yankee Springs Township, Precinct 1W (Barry)",Straight Party,,Green Party,GRN,0
+Allegan,"Yankee Springs Township, Precinct 1W (Barry)",Straight Party,,Natural Law Party,NAT,0
+Allegan,"Yankee Springs Township, Precinct 2W (Barry)",Straight Party,,Democratic Party,DEM,0
+Allegan,"Yankee Springs Township, Precinct 2W (Barry)",Straight Party,,Republican Party,REP,0
+Allegan,"Yankee Springs Township, Precinct 2W (Barry)",Straight Party,,Libertarian Party,LIB,0
+Allegan,"Yankee Springs Township, Precinct 2W (Barry)",Straight Party,,U.S. Taxpayers Party,UST,0
+Allegan,"Yankee Springs Township, Precinct 2W (Barry)",Straight Party,,Working Class Party,WC,0
+Allegan,"Yankee Springs Township, Precinct 2W (Barry)",Straight Party,,Green Party,GRN,0
+Allegan,"Yankee Springs Township, Precinct 2W (Barry)",Straight Party,,Natural Law Party,NAT,0
+Allegan,"Prairieville Township, Precinct 1PL (Barry)",Straight Party,,Democratic Party,DEM,0
+Allegan,"Prairieville Township, Precinct 1PL (Barry)",Straight Party,,Republican Party,REP,0
+Allegan,"Prairieville Township, Precinct 1PL (Barry)",Straight Party,,Libertarian Party,LIB,0
+Allegan,"Prairieville Township, Precinct 1PL (Barry)",Straight Party,,U.S. Taxpayers Party,UST,0
+Allegan,"Prairieville Township, Precinct 1PL (Barry)",Straight Party,,Working Class Party,WC,0
+Allegan,"Prairieville Township, Precinct 1PL (Barry)",Straight Party,,Green Party,GRN,0
+Allegan,"Prairieville Township, Precinct 1PL (Barry)",Straight Party,,Natural Law Party,NAT,0
 Allegan,"City of Holland, Ward 4, Precinct 9 (Ottawa)",U.S. House,2,Bryan Berghoef,DEM,137
 Allegan,"City of Holland, Ward 4, Precinct 9 (Ottawa)",U.S. House,2,Bill Huizenga,REP,158
 Allegan,"City of Holland, Ward 4, Precinct 9 (Ottawa)",U.S. House,2,Max Riekse,LIB,3
@@ -1599,75 +1599,75 @@ Allegan,"City of South Haven, Ward 3, Precinct 2 (Van Buren County)",U.S. Senate
 Allegan,"City of South Haven, Ward 3, Precinct 2 (Van Buren County)",U.S. Senate,,Marcia Squier,GRN,0
 Allegan,"City of South Haven, Ward 3, Precinct 2 (Van Buren County)",U.S. Senate,,Doug Dern,NAT,0
 Allegan,"City of South Haven, Ward 3, Precinct 2 (Van Buren County)",U.S. Senate,,Write-Ins,,0
-Allegan,"zByron Township, Precinct 5 (Kent)",U.S. Senate,,Gary Peters,DEM,0
-Allegan,"zByron Township, Precinct 5 (Kent)",U.S. Senate,,John James,REP,0
-Allegan,"zByron Township, Precinct 5 (Kent)",U.S. Senate,,Valerie L. Willis,UST,0
-Allegan,"zByron Township, Precinct 5 (Kent)",U.S. Senate,,Marcia Squier,GRN,0
-Allegan,"zByron Township, Precinct 5 (Kent)",U.S. Senate,,Doug Dern,NAT,0
-Allegan,"zByron Township, Precinct 5 (Kent)",U.S. Senate,,Write-Ins,,0
-Allegan,"zPine Grove Township, Precinct 1B (Van Buren)",U.S. Senate,,Gary Peters,DEM,0
-Allegan,"zPine Grove Township, Precinct 1B (Van Buren)",U.S. Senate,,John James,REP,0
-Allegan,"zPine Grove Township, Precinct 1B (Van Buren)",U.S. Senate,,Valerie L. Willis,UST,0
-Allegan,"zPine Grove Township, Precinct 1B (Van Buren)",U.S. Senate,,Marcia Squier,GRN,0
-Allegan,"zPine Grove Township, Precinct 1B (Van Buren)",U.S. Senate,,Doug Dern,NAT,0
-Allegan,"zPine Grove Township, Precinct 1B (Van Buren)",U.S. Senate,,Write-Ins,,0
-Allegan,"zAlamo Township, Precinct 1 (Kalamazoo)",U.S. Senate,,Gary Peters,DEM,0
-Allegan,"zAlamo Township, Precinct 1 (Kalamazoo)",U.S. Senate,,John James,REP,0
-Allegan,"zAlamo Township, Precinct 1 (Kalamazoo)",U.S. Senate,,Valerie L. Willis,UST,0
-Allegan,"zAlamo Township, Precinct 1 (Kalamazoo)",U.S. Senate,,Marcia Squier,GRN,0
-Allegan,"zAlamo Township, Precinct 1 (Kalamazoo)",U.S. Senate,,Doug Dern,NAT,0
-Allegan,"zAlamo Township, Precinct 1 (Kalamazoo)",U.S. Senate,,Write-Ins,,0
-Allegan,"zAlamo Township, Precinct 2 (Kalamazoo)",U.S. Senate,,Gary Peters,DEM,0
-Allegan,"zAlamo Township, Precinct 2 (Kalamazoo)",U.S. Senate,,John James,REP,0
-Allegan,"zAlamo Township, Precinct 2 (Kalamazoo)",U.S. Senate,,Valerie L. Willis,UST,0
-Allegan,"zAlamo Township, Precinct 2 (Kalamazoo)",U.S. Senate,,Marcia Squier,GRN,0
-Allegan,"zAlamo Township, Precinct 2 (Kalamazoo)",U.S. Senate,,Doug Dern,NAT,0
-Allegan,"zAlamo Township, Precinct 2 (Kalamazoo)",U.S. Senate,,Write-Ins,,0
-Allegan,"zCooper Township, Precinct 1 (Kalamazoo)",U.S. Senate,,Gary Peters,DEM,0
-Allegan,"zCooper Township, Precinct 1 (Kalamazoo)",U.S. Senate,,John James,REP,0
-Allegan,"zCooper Township, Precinct 1 (Kalamazoo)",U.S. Senate,,Valerie L. Willis,UST,0
-Allegan,"zCooper Township, Precinct 1 (Kalamazoo)",U.S. Senate,,Marcia Squier,GRN,0
-Allegan,"zCooper Township, Precinct 1 (Kalamazoo)",U.S. Senate,,Doug Dern,NAT,0
-Allegan,"zCooper Township, Precinct 1 (Kalamazoo)",U.S. Senate,,Write-Ins,,0
-Allegan,"zCooper Township, Precinct 2 (Kalamazoo)",U.S. Senate,,Gary Peters,DEM,0
-Allegan,"zCooper Township, Precinct 2 (Kalamazoo)",U.S. Senate,,John James,REP,0
-Allegan,"zCooper Township, Precinct 2 (Kalamazoo)",U.S. Senate,,Valerie L. Willis,UST,0
-Allegan,"zCooper Township, Precinct 2 (Kalamazoo)",U.S. Senate,,Marcia Squier,GRN,0
-Allegan,"zCooper Township, Precinct 2 (Kalamazoo)",U.S. Senate,,Doug Dern,NAT,0
-Allegan,"zCooper Township, Precinct 2 (Kalamazoo)",U.S. Senate,,Write-Ins,,0
-Allegan,"zCooper Township, Precinct 4 (Kalamazoo)",U.S. Senate,,Gary Peters,DEM,0
-Allegan,"zCooper Township, Precinct 4 (Kalamazoo)",U.S. Senate,,John James,REP,0
-Allegan,"zCooper Township, Precinct 4 (Kalamazoo)",U.S. Senate,,Valerie L. Willis,UST,0
-Allegan,"zCooper Township, Precinct 4 (Kalamazoo)",U.S. Senate,,Marcia Squier,GRN,0
-Allegan,"zCooper Township, Precinct 4 (Kalamazoo)",U.S. Senate,,Doug Dern,NAT,0
-Allegan,"zCooper Township, Precinct 4 (Kalamazoo)",U.S. Senate,,Write-Ins,,0
-Allegan,"zOshtemo Township, Precinct 1 (Kalamazoo)",U.S. Senate,,Gary Peters,DEM,0
-Allegan,"zOshtemo Township, Precinct 1 (Kalamazoo)",U.S. Senate,,John James,REP,0
-Allegan,"zOshtemo Township, Precinct 1 (Kalamazoo)",U.S. Senate,,Valerie L. Willis,UST,0
-Allegan,"zOshtemo Township, Precinct 1 (Kalamazoo)",U.S. Senate,,Marcia Squier,GRN,0
-Allegan,"zOshtemo Township, Precinct 1 (Kalamazoo)",U.S. Senate,,Doug Dern,NAT,0
-Allegan,"zOshtemo Township, Precinct 1 (Kalamazoo)",U.S. Senate,,Write-Ins,,0
-Allegan,"zOrangeville Township, Precinct 1 (Barry)",U.S. Senate,,Gary Peters,DEM,0
-Allegan,"zOrangeville Township, Precinct 1 (Barry)",U.S. Senate,,John James,REP,0
-Allegan,"zOrangeville Township, Precinct 1 (Barry)",U.S. Senate,,Valerie L. Willis,UST,0
-Allegan,"zOrangeville Township, Precinct 1 (Barry)",U.S. Senate,,Marcia Squier,GRN,0
-Allegan,"zOrangeville Township, Precinct 1 (Barry)",U.S. Senate,,Doug Dern,NAT,0
-Allegan,"zOrangeville Township, Precinct 1 (Barry)",U.S. Senate,,Write-Ins,,0
-Allegan,"zYankee Springs Township, Precinct 1W (Barry)",U.S. Senate,,Gary Peters,DEM,0
-Allegan,"zYankee Springs Township, Precinct 1W (Barry)",U.S. Senate,,John James,REP,0
-Allegan,"zYankee Springs Township, Precinct 1W (Barry)",U.S. Senate,,Valerie L. Willis,UST,0
-Allegan,"zYankee Springs Township, Precinct 1W (Barry)",U.S. Senate,,Marcia Squier,GRN,0
-Allegan,"zYankee Springs Township, Precinct 1W (Barry)",U.S. Senate,,Doug Dern,NAT,0
-Allegan,"zYankee Springs Township, Precinct 1W (Barry)",U.S. Senate,,Write-Ins,,0
-Allegan,"zYankee Springs Township, Precinct 2W (Barry)",U.S. Senate,,Gary Peters,DEM,0
-Allegan,"zYankee Springs Township, Precinct 2W (Barry)",U.S. Senate,,John James,REP,0
-Allegan,"zYankee Springs Township, Precinct 2W (Barry)",U.S. Senate,,Valerie L. Willis,UST,0
-Allegan,"zYankee Springs Township, Precinct 2W (Barry)",U.S. Senate,,Marcia Squier,GRN,0
-Allegan,"zYankee Springs Township, Precinct 2W (Barry)",U.S. Senate,,Doug Dern,NAT,0
-Allegan,"zYankee Springs Township, Precinct 2W (Barry)",U.S. Senate,,Write-Ins,,0
-Allegan,"zPrairieville Township, Precinct 1PL (Barry)",U.S. Senate,,Gary Peters,DEM,0
-Allegan,"zPrairieville Township, Precinct 1PL (Barry)",U.S. Senate,,John James,REP,0
-Allegan,"zPrairieville Township, Precinct 1PL (Barry)",U.S. Senate,,Valerie L. Willis,UST,0
-Allegan,"zPrairieville Township, Precinct 1PL (Barry)",U.S. Senate,,Marcia Squier,GRN,0
-Allegan,"zPrairieville Township, Precinct 1PL (Barry)",U.S. Senate,,Doug Dern,NAT,0
-Allegan,"zPrairieville Township, Precinct 1PL (Barry)",U.S. Senate,,Write-Ins,,0
+Allegan,"Byron Township, Precinct 5 (Kent)",U.S. Senate,,Gary Peters,DEM,0
+Allegan,"Byron Township, Precinct 5 (Kent)",U.S. Senate,,John James,REP,0
+Allegan,"Byron Township, Precinct 5 (Kent)",U.S. Senate,,Valerie L. Willis,UST,0
+Allegan,"Byron Township, Precinct 5 (Kent)",U.S. Senate,,Marcia Squier,GRN,0
+Allegan,"Byron Township, Precinct 5 (Kent)",U.S. Senate,,Doug Dern,NAT,0
+Allegan,"Byron Township, Precinct 5 (Kent)",U.S. Senate,,Write-Ins,,0
+Allegan,"Pine Grove Township, Precinct 1B (Van Buren)",U.S. Senate,,Gary Peters,DEM,0
+Allegan,"Pine Grove Township, Precinct 1B (Van Buren)",U.S. Senate,,John James,REP,0
+Allegan,"Pine Grove Township, Precinct 1B (Van Buren)",U.S. Senate,,Valerie L. Willis,UST,0
+Allegan,"Pine Grove Township, Precinct 1B (Van Buren)",U.S. Senate,,Marcia Squier,GRN,0
+Allegan,"Pine Grove Township, Precinct 1B (Van Buren)",U.S. Senate,,Doug Dern,NAT,0
+Allegan,"Pine Grove Township, Precinct 1B (Van Buren)",U.S. Senate,,Write-Ins,,0
+Allegan,"Alamo Township, Precinct 1 (Kalamazoo)",U.S. Senate,,Gary Peters,DEM,0
+Allegan,"Alamo Township, Precinct 1 (Kalamazoo)",U.S. Senate,,John James,REP,0
+Allegan,"Alamo Township, Precinct 1 (Kalamazoo)",U.S. Senate,,Valerie L. Willis,UST,0
+Allegan,"Alamo Township, Precinct 1 (Kalamazoo)",U.S. Senate,,Marcia Squier,GRN,0
+Allegan,"Alamo Township, Precinct 1 (Kalamazoo)",U.S. Senate,,Doug Dern,NAT,0
+Allegan,"Alamo Township, Precinct 1 (Kalamazoo)",U.S. Senate,,Write-Ins,,0
+Allegan,"Alamo Township, Precinct 2 (Kalamazoo)",U.S. Senate,,Gary Peters,DEM,0
+Allegan,"Alamo Township, Precinct 2 (Kalamazoo)",U.S. Senate,,John James,REP,0
+Allegan,"Alamo Township, Precinct 2 (Kalamazoo)",U.S. Senate,,Valerie L. Willis,UST,0
+Allegan,"Alamo Township, Precinct 2 (Kalamazoo)",U.S. Senate,,Marcia Squier,GRN,0
+Allegan,"Alamo Township, Precinct 2 (Kalamazoo)",U.S. Senate,,Doug Dern,NAT,0
+Allegan,"Alamo Township, Precinct 2 (Kalamazoo)",U.S. Senate,,Write-Ins,,0
+Allegan,"Cooper Township, Precinct 1 (Kalamazoo)",U.S. Senate,,Gary Peters,DEM,0
+Allegan,"Cooper Township, Precinct 1 (Kalamazoo)",U.S. Senate,,John James,REP,0
+Allegan,"Cooper Township, Precinct 1 (Kalamazoo)",U.S. Senate,,Valerie L. Willis,UST,0
+Allegan,"Cooper Township, Precinct 1 (Kalamazoo)",U.S. Senate,,Marcia Squier,GRN,0
+Allegan,"Cooper Township, Precinct 1 (Kalamazoo)",U.S. Senate,,Doug Dern,NAT,0
+Allegan,"Cooper Township, Precinct 1 (Kalamazoo)",U.S. Senate,,Write-Ins,,0
+Allegan,"Cooper Township, Precinct 2 (Kalamazoo)",U.S. Senate,,Gary Peters,DEM,0
+Allegan,"Cooper Township, Precinct 2 (Kalamazoo)",U.S. Senate,,John James,REP,0
+Allegan,"Cooper Township, Precinct 2 (Kalamazoo)",U.S. Senate,,Valerie L. Willis,UST,0
+Allegan,"Cooper Township, Precinct 2 (Kalamazoo)",U.S. Senate,,Marcia Squier,GRN,0
+Allegan,"Cooper Township, Precinct 2 (Kalamazoo)",U.S. Senate,,Doug Dern,NAT,0
+Allegan,"Cooper Township, Precinct 2 (Kalamazoo)",U.S. Senate,,Write-Ins,,0
+Allegan,"Cooper Township, Precinct 4 (Kalamazoo)",U.S. Senate,,Gary Peters,DEM,0
+Allegan,"Cooper Township, Precinct 4 (Kalamazoo)",U.S. Senate,,John James,REP,0
+Allegan,"Cooper Township, Precinct 4 (Kalamazoo)",U.S. Senate,,Valerie L. Willis,UST,0
+Allegan,"Cooper Township, Precinct 4 (Kalamazoo)",U.S. Senate,,Marcia Squier,GRN,0
+Allegan,"Cooper Township, Precinct 4 (Kalamazoo)",U.S. Senate,,Doug Dern,NAT,0
+Allegan,"Cooper Township, Precinct 4 (Kalamazoo)",U.S. Senate,,Write-Ins,,0
+Allegan,"Oshtemo Township, Precinct 1 (Kalamazoo)",U.S. Senate,,Gary Peters,DEM,0
+Allegan,"Oshtemo Township, Precinct 1 (Kalamazoo)",U.S. Senate,,John James,REP,0
+Allegan,"Oshtemo Township, Precinct 1 (Kalamazoo)",U.S. Senate,,Valerie L. Willis,UST,0
+Allegan,"Oshtemo Township, Precinct 1 (Kalamazoo)",U.S. Senate,,Marcia Squier,GRN,0
+Allegan,"Oshtemo Township, Precinct 1 (Kalamazoo)",U.S. Senate,,Doug Dern,NAT,0
+Allegan,"Oshtemo Township, Precinct 1 (Kalamazoo)",U.S. Senate,,Write-Ins,,0
+Allegan,"Orangeville Township, Precinct 1 (Barry)",U.S. Senate,,Gary Peters,DEM,0
+Allegan,"Orangeville Township, Precinct 1 (Barry)",U.S. Senate,,John James,REP,0
+Allegan,"Orangeville Township, Precinct 1 (Barry)",U.S. Senate,,Valerie L. Willis,UST,0
+Allegan,"Orangeville Township, Precinct 1 (Barry)",U.S. Senate,,Marcia Squier,GRN,0
+Allegan,"Orangeville Township, Precinct 1 (Barry)",U.S. Senate,,Doug Dern,NAT,0
+Allegan,"Orangeville Township, Precinct 1 (Barry)",U.S. Senate,,Write-Ins,,0
+Allegan,"Yankee Springs Township, Precinct 1W (Barry)",U.S. Senate,,Gary Peters,DEM,0
+Allegan,"Yankee Springs Township, Precinct 1W (Barry)",U.S. Senate,,John James,REP,0
+Allegan,"Yankee Springs Township, Precinct 1W (Barry)",U.S. Senate,,Valerie L. Willis,UST,0
+Allegan,"Yankee Springs Township, Precinct 1W (Barry)",U.S. Senate,,Marcia Squier,GRN,0
+Allegan,"Yankee Springs Township, Precinct 1W (Barry)",U.S. Senate,,Doug Dern,NAT,0
+Allegan,"Yankee Springs Township, Precinct 1W (Barry)",U.S. Senate,,Write-Ins,,0
+Allegan,"Yankee Springs Township, Precinct 2W (Barry)",U.S. Senate,,Gary Peters,DEM,0
+Allegan,"Yankee Springs Township, Precinct 2W (Barry)",U.S. Senate,,John James,REP,0
+Allegan,"Yankee Springs Township, Precinct 2W (Barry)",U.S. Senate,,Valerie L. Willis,UST,0
+Allegan,"Yankee Springs Township, Precinct 2W (Barry)",U.S. Senate,,Marcia Squier,GRN,0
+Allegan,"Yankee Springs Township, Precinct 2W (Barry)",U.S. Senate,,Doug Dern,NAT,0
+Allegan,"Yankee Springs Township, Precinct 2W (Barry)",U.S. Senate,,Write-Ins,,0
+Allegan,"Prairieville Township, Precinct 1PL (Barry)",U.S. Senate,,Gary Peters,DEM,0
+Allegan,"Prairieville Township, Precinct 1PL (Barry)",U.S. Senate,,John James,REP,0
+Allegan,"Prairieville Township, Precinct 1PL (Barry)",U.S. Senate,,Valerie L. Willis,UST,0
+Allegan,"Prairieville Township, Precinct 1PL (Barry)",U.S. Senate,,Marcia Squier,GRN,0
+Allegan,"Prairieville Township, Precinct 1PL (Barry)",U.S. Senate,,Doug Dern,NAT,0
+Allegan,"Prairieville Township, Precinct 1PL (Barry)",U.S. Senate,,Write-Ins,,0


### PR DESCRIPTION
This removes an erroneous `z` that preceded some precinct names.

